### PR TITLE
Fix button in Notion's popup/dialog view

### DIFF
--- a/src/content/notion.js
+++ b/src/content/notion.js
@@ -13,7 +13,7 @@ function createWrapper (link) {
   return wrapper;
 }
 
-// Selectors here are madness, it works for as of Dec 4th 2019
+// Selectors here are madness, it works for as of Apr 8th 2022
 // Button renders in popup/dialog view
 togglbutton.render(
   '.notion-peek-renderer:not(.toggl)',
@@ -33,7 +33,7 @@ togglbutton.render(
 
     const root = elem.querySelector('div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)');
     if (root) {
-      root.prepend(wrapper);
+      root.before(wrapper);
     }
   }
 );


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Fixes #2034 by positioning the Toggl button before the selector instead of inside.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

Preview this in a Notion modal after clicking on an item from a database.

## :memo: Links to relevant issues or information

#2032
